### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -29,19 +29,19 @@ rightToLeft	KEYWORD2
 scrollDisplayLeft	KEYWORD2
 scrollDisplayRight	KEYWORD2
 createChar	KEYWORD2
-moveCursorAfterInstruction KEYWORD2
-moveDisplayAfterInstruction KEYWORD2
-holdCursor KEYWORD2
-holdDisplay KEYWORD2
-shiftCursor KEYWORD2
-shiftDisplay KEYWORD2
-leftToRight KEYWORD2
-rightToLeft KEYWORD2
-autoscroll KEYWORD2
-noAutoscroll KEYWORD2
-setCursor KEYWORD2
-command KEYWORD2
-writechar KEYWORD2
+moveCursorAfterInstruction	KEYWORD2
+moveDisplayAfterInstruction	KEYWORD2
+holdCursor	KEYWORD2
+holdDisplay	KEYWORD2
+shiftCursor	KEYWORD2
+shiftDisplay	KEYWORD2
+leftToRight	KEYWORD2
+rightToLeft	KEYWORD2
+autoscroll	KEYWORD2
+noAutoscroll	KEYWORD2
+setCursor	KEYWORD2
+command	KEYWORD2
+writechar	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords